### PR TITLE
Bump supports-color dep to ^4.0.0 from ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	],
 	"dependencies": {
 		"meow": "^3.7.0",
-		"supports-color": "^4.0.0"
+		"supports-color": "^4.1.0"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	],
 	"dependencies": {
 		"meow": "^3.7.0",
-		"supports-color": "^3.0.0"
+		"supports-color": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "*",


### PR DESCRIPTION
It's a major version jump, but in my testing, I can't make it fail.

I'm sure @sindresorhus or @Qix- are better aware of any potential quirks I may not be aware of.

This allows the CLI component to work on Windows, now that chalk/supports-color#56 is merged.